### PR TITLE
Add extras to gofannon ('solves' arithmetic bug)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pymilvus = {extras = ["model"], version = "^2.5.4"}
 datasets = "^3.3.2"
 tiktoken = "^0.9.0"
 neo4j = "^5.28.1"
-gofannon = "^0.25.10.1"
+gofannon = {extras = ["langchain", "smolagents"], version = "^0.25.10.1"}
 langchain-community = "^0.3.18"
 langchain-huggingface = "^0.1.2"
 aisuite = {extras = ["openai,anthropic"], version = "^0.1.10"}


### PR DESCRIPTION
Closes #10 

By inspection, the example was failing because smolagents (and others) are only installed as extras. I added them and all seems to be well. 

My 'testing' is here: https://colab.research.google.com/drive/14_dSwW2KOb-OCM3SPWu-aoDwu4SfnQZW?usp=sharing

But it didn't seem to return the answer. But I don't think that's related to this