### PR TITLE
factor triples out of graph_rag driver

### DIFF
--- a/demo/domains/legal.py
+++ b/demo/domains/legal.py
@@ -60,7 +60,7 @@ def retrieve_documents() -> List[Document]:
         hf_dataset_id,
     )
 
-    for doc, i in enumerate(docs):
+    for i, doc in enumerate(docs):
         doc.metadata["dataset_index"] = i
 
     return docs

--- a/demo/typer/legal.py
+++ b/demo/typer/legal.py
@@ -34,14 +34,14 @@ def extract():
         legal_config.retrieve_documents,
         legal_config.doc_as_rich,
         legal_config.entity_csv_file,
-        legal_config.doc_direct_triples,
         legal_config.default_chunk_extraction_model_id,
-        legal_config.triples_from_chunk,
+        legal_config.chunk_extract,
+        legal_config.doc_enrichments,
     )
 
 
 @app.command(
-    help=f"Load the entity graph from {legal_config.entity_csv_file} and load into graph db."
+    help=f"Load the entity graph from {legal_config.entity_jsonl_file} and load into graph db."
 )
 def load_graph():
 
@@ -49,7 +49,9 @@ def load_graph():
         legal_config.neo4j_uri, legal_config.neo4j_username, legal_config.neo4j_password
     )
 
-    load_entity_graph(driver, legal_config.entity_csv_file, legal_config.add_triple)
+    load_entity_graph(
+        driver, legal_config.entity_jsonl_file, legal_config.doc_enrichments_to_graph
+    )
 
     driver.close()
 
@@ -113,8 +115,8 @@ def ask():
         legal_config.embedding_model_id,
         driver,
         legal_config.default_generation_model_id,
-        legal_config.triples_from_query,
-        legal_config.generation_prompts,
+        legal_config.extract_to_context,
+        legal_config.context_to_prompts,
     )
 
     if answer:

--- a/demo/typer/legal.py
+++ b/demo/typer/legal.py
@@ -26,14 +26,14 @@ Graph extraction and question answering with GraphRAG on caselaw.
 
 
 @app.command(
-    help=f"Extract entities from {legal_config.hf_dataset_id} and write to {legal_config.entity_csv_file}."
+    help=f"Extract entities from {legal_config.hf_dataset_id} and write to {legal_config.entity_jsonl_file}."
 )
 def extract():
 
     extract_entities(
         legal_config.retrieve_documents,
         legal_config.doc_as_rich,
-        legal_config.entity_csv_file,
+        legal_config.entity_jsonl_file,
         legal_config.default_chunk_extraction_model_id,
         legal_config.chunk_extract,
         legal_config.doc_enrichments,
@@ -115,6 +115,7 @@ def ask():
         legal_config.embedding_model_id,
         driver,
         legal_config.default_generation_model_id,
+        legal_config.query_extract,
         legal_config.extract_to_context,
         legal_config.context_to_prompts,
     )

--- a/proscenium/scripts/graph_rag.py
+++ b/proscenium/scripts/graph_rag.py
@@ -43,7 +43,7 @@ def extract_from_document_chunks(
         ce = chunk_extract(chunk_extraction_model_id, chunk, doc)
 
         print("Extract model in chunk", i + 1, "of", len(chunks))
-        print(Panel(ce))
+        print(Panel(str(ce)))
 
         extract_models.append(ce)
 


### PR DESCRIPTION
- refactor away from persisting triples after extraction in favor of a more flexible jsonl
- similar for query processing
- store the dataset index of each document in the graph to facilitate a faster retrieve (still a hack, but better than the previous state)
